### PR TITLE
Make sure that the plugin works when the app backend moves to Django 1.8

### DIFF
--- a/cmsplugin_socialschools/static/cmsplugin_socialschools/js/socialschools.js
+++ b/cmsplugin_socialschools/static/cmsplugin_socialschools/js/socialschools.js
@@ -34,7 +34,7 @@
 
         this.getFromUrl = function(url, options, callback) {
           that.ajax = $.ajax({
-            dataType: 'jsonp',
+            dataType: 'json',
             url: url,
             data: options,
             success: function (data) {


### PR DESCRIPTION
Ensure that plugin will work fine with django1.8 where the default
datatype has been changed to json.

Fixes #51

Reported-by:
Signed-off-by: Vinit Kumar <vinit1414.08@bitmesra.ac.in>